### PR TITLE
Shape color change in draw.io interface fix

### DIFF
--- a/build.js
+++ b/build.js
@@ -11,9 +11,26 @@ var svgIcons = fs.readdirSync(srcPath).map(function (p) {
 });
 
 function mxLibraryEntry(svg, color) {
+  // Create a color lookup table to convert web standard olor names to hex values for Draw.io
+  colorLookup = {
+    black: '#000000',
+    white: '#ffffff',
+    red: '#FF0000',
+    green: '#008000',
+    blue: '#0000FF',
+    navy: '#000080',
+    teal: '#008080',
+    olive: '#808000',
+    purple: '#800080',
+    orange: '#FFA500',
+    brown: '#A52A2A',
+    gray: '#808080',
+  };
+  
   var xml = svg.contents;
   if (color)
-    xml = svg.contents.replace('<path d', '<path fill="' + color.slice(color.indexOf('=') + 1) + '" d');
+    // Modify the path to insert a CSS definiation for the path element that will later be picked up in Draw.io
+    xml = svg.contents.replace('<path d', '<style type="text/css">path {fill:' + colorLookup[color.slice(color.indexOf('=') + 1)] + ';}</style><path d');
   var b64EncodedSvg = Buffer.from(xml).toString("base64");
 
   // Unlike the btoa method in web browsers, the Buffer.toString method can be fed an int array, and
@@ -37,7 +54,8 @@ function mxLibrary(entries) {
 
 function output(color) {
   fs.writeFileSync(
-    path.join(distPath, 'FontAwesome' + (color ? ' - ' + color : '')),
+    // add the file extention to make it easier to open the file
+    path.join(distPath, 'FontAwesome' + (color ? ' - ' + color : '') + '.xml'),
     mxLibrary(svgIcons.map((file, index, arr) => {
       process.stdout.write(" ");
       process.stdout.clearLine();
@@ -51,7 +69,7 @@ function output(color) {
 
 if (process.argv[2] === 'all')
   [
-    '',
+    'black',
     'white',
     'red',
     'green',

--- a/build.js
+++ b/build.js
@@ -11,9 +11,28 @@ var svgIcons = fs.readdirSync(srcPath).map(function (p) {
 });
 
 function mxLibraryEntry(svg, color) {
+  // Create a color lookup table to convert web standard color names to hex values
+  // Color names work, but show up incorrectly in the Draw.io interface
+  colorLookup = {
+    black: '#000000',
+    white: '#ffffff',
+    red: '#FF0000',
+    green: '#008000',
+    blue: '#0000FF',
+    navy: '#000080',
+    teal: '#008080',
+    olive: '#808000',
+    purple: '#800080',
+    orange: '#FFA500',
+    brown: '#A52A2A',
+    gray: '#808080',
+  };
+  
   var xml = svg.contents;
   if (color)
-    xml = svg.contents.replace('<path d', '<path fill="' + color.slice(color.indexOf('=') + 1) + '" d');
+    // Modify the path to insert a CSS definition for the path element 
+    // This will later be picked up in Draw.io with the help of the "editableCssRules=path;" style property hack
+    xml = svg.contents.replace('<path d', '<style type="text/css">path {fill:' + colorLookup[color.slice(color.indexOf('=') + 1)] + ';}</style><path d');
   var b64EncodedSvg = Buffer.from(xml).toString("base64");
 
   // Unlike the btoa method in web browsers, the Buffer.toString method can be fed an int array, and
@@ -37,7 +56,8 @@ function mxLibrary(entries) {
 
 function output(color) {
   fs.writeFileSync(
-    path.join(distPath, 'FontAwesome' + (color ? ' - ' + color : '')),
+    // add the file extention to make it easier to open the file
+    path.join(distPath, 'FontAwesome' + (color ? ' - ' + color : '') + '.xml'),
     mxLibrary(svgIcons.map((file, index, arr) => {
       process.stdout.write(" ");
       process.stdout.clearLine();
@@ -50,8 +70,10 @@ function output(color) {
 }
 
 if (process.argv[2] === 'all')
+  // Now that colors can be assigned directly in Draw.io this part may not be needed
+  // Still, someone may want to generate a library with a default color other than black
   [
-    '',
+    'black',
     'white',
     'red',
     'green',
@@ -67,4 +89,5 @@ if (process.argv[2] === 'all')
     output(color);
   });
 else
-  output(color);
+  // Provide a backstop color value since color values not in the lookup table will cause issues
+  output('black');

--- a/build.js
+++ b/build.js
@@ -11,26 +11,9 @@ var svgIcons = fs.readdirSync(srcPath).map(function (p) {
 });
 
 function mxLibraryEntry(svg, color) {
-  // Create a color lookup table to convert web standard olor names to hex values for Draw.io
-  colorLookup = {
-    black: '#000000',
-    white: '#ffffff',
-    red: '#FF0000',
-    green: '#008000',
-    blue: '#0000FF',
-    navy: '#000080',
-    teal: '#008080',
-    olive: '#808000',
-    purple: '#800080',
-    orange: '#FFA500',
-    brown: '#A52A2A',
-    gray: '#808080',
-  };
-  
   var xml = svg.contents;
   if (color)
-    // Modify the path to insert a CSS definiation for the path element that will later be picked up in Draw.io
-    xml = svg.contents.replace('<path d', '<style type="text/css">path {fill:' + colorLookup[color.slice(color.indexOf('=') + 1)] + ';}</style><path d');
+    xml = svg.contents.replace('<path d', '<path fill="' + color.slice(color.indexOf('=') + 1) + '" d');
   var b64EncodedSvg = Buffer.from(xml).toString("base64");
 
   // Unlike the btoa method in web browsers, the Buffer.toString method can be fed an int array, and
@@ -54,8 +37,7 @@ function mxLibrary(entries) {
 
 function output(color) {
   fs.writeFileSync(
-    // add the file extention to make it easier to open the file
-    path.join(distPath, 'FontAwesome' + (color ? ' - ' + color : '') + '.xml'),
+    path.join(distPath, 'FontAwesome' + (color ? ' - ' + color : '')),
     mxLibrary(svgIcons.map((file, index, arr) => {
       process.stdout.write(" ");
       process.stdout.clearLine();
@@ -69,7 +51,7 @@ function output(color) {
 
 if (process.argv[2] === 'all')
   [
-    'black',
+    '',
     'white',
     'red',
     'green',

--- a/wrapper.xml
+++ b/wrapper.xml
@@ -2,7 +2,7 @@
   <root>
     <mxCell id="0"/>
     <mxCell id="1" parent="0"/>
-    <mxCell id="2" value="" style="shape=image;aspect=fixed;image=data:image/svg+xml,%xml%;connectable=0;movable=1;verticalLabelPosition=bottom;resizable=1;rotatable=0;cloneable=0;deletable=1;recursiveResize=0;imageBackground=none;verticalAlign=top;" vertex="1" parent="1">
+    <mxCell id="2" value="" style="editableCssRules=path;shape=image;aspect=fixed;image=data:image/svg+xml,%xml%;connectable=0;movable=1;verticalLabelPosition=bottom;resizable=1;rotatable=0;cloneable=0;deletable=1;recursiveResize=0;imageBackground=none;verticalAlign=top;" vertex="1" parent="1">
       <mxGeometry width="16" height="16" as="geometry"/>
     </mxCell>
   </root>

--- a/wrapper.xml
+++ b/wrapper.xml
@@ -2,7 +2,7 @@
   <root>
     <mxCell id="0"/>
     <mxCell id="1" parent="0"/>
-    <mxCell id="2" value="" style="editableCssRules=path;shape=image;aspect=fixed;image=data:image/svg+xml,%xml%;connectable=0;movable=1;verticalLabelPosition=bottom;resizable=1;rotatable=0;cloneable=0;deletable=1;recursiveResize=0;imageBackground=none;verticalAlign=top;" vertex="1" parent="1">
+    <mxCell id="2" value="" style="shape=image;aspect=fixed;image=data:image/svg+xml,%xml%;connectable=0;movable=1;verticalLabelPosition=bottom;resizable=1;rotatable=0;cloneable=0;deletable=1;recursiveResize=0;imageBackground=none;verticalAlign=top;" vertex="1" parent="1">
       <mxGeometry width="16" height="16" as="geometry"/>
     </mxCell>
   </root>


### PR DESCRIPTION
I made some slight changes to generated XML data to get the shape fill colors editable in in the draw.io interface. Comments added in the code. The actual fix is a bit of a hack, but it works.